### PR TITLE
support fasta input from gffread; minor fixes

### DIFF
--- a/src/build_index.rs
+++ b/src/build_index.rs
@@ -243,7 +243,7 @@ fn make_dbg_index<K: Kmer + Sync + Send>(
         let node_id = node.node_id;
 
         for (offset, kmer) in node.into_iter().enumerate() {
-            let index = mphf.try_hash(&kmer).expect("can't find kmer is DBG graph!");
+            let index = mphf.try_hash(&kmer).expect("can't find kmer in DBG graph!");
             node_and_offsets[index as usize] = (node_id as u32, offset as u32);
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,11 +2,13 @@
 
 use debruijn::kmer;
 
-// transcriptome fasta headers
-pub const FASTA_FORMAT_GENCODE: u8 = 0;
-pub const FASTA_FORMAT_ENSEMBL: u8 = 1;
-// (output from cufflinks gffread)
-pub const FASTA_FORMAT_CUFFLINKS: u8 = 2;
+// transcriptome fasta header formats
+pub enum FastaFormat {
+    Unknown,
+    Gencode,
+    Ensembl,
+    Gffread
+}
 
 // main configs
 pub const MEM_SIZE: usize = 1;

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@ use debruijn::kmer;
 // transcriptome fasta headers
 pub const FASTA_FORMAT_GENCODE: u8 = 0;
 pub const FASTA_FORMAT_ENSEMBL: u8 = 1;
+// (output from cufflinks gffread)
+pub const FASTA_FORMAT_CUFFLINKS: u8 = 2;
 
 // main configs
 pub const MEM_SIZE: usize = 1;

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ pub enum FastaFormat {
     Unknown,
     Gencode,
     Ensembl,
-    Gffread
+    Gffread,
 }
 
 // main configs

--- a/src/mappability.rs
+++ b/src/mappability.rs
@@ -8,7 +8,7 @@ use crate::config::MAPPABILITY_COUNTS_LEN;
 use crate::pseudoaligner::Pseudoaligner;
 
 // 1. Given graph, build a data structure of transcripts
-//    - tx: tx_id, gene_name,
+//    - tx: tx_name, gene_name,
 // 2. For each de Bruijn graph node
 //    - count = number of kmers (L - K + 1)
 //    - transcript multiplicity = # of colors (size of equiv class)

--- a/src/mappability.rs
+++ b/src/mappability.rs
@@ -8,14 +8,14 @@ use crate::config::MAPPABILITY_COUNTS_LEN;
 use crate::pseudoaligner::Pseudoaligner;
 
 // 1. Given graph, build a data structure of transcripts
-//    - tx: tx_name, gene_name,
+//    - tx: tx_id, gene_name,
 // 2. For each de Bruijn graph node
 //    - count = number of kmers (L - K + 1)
 //    - transcript multiplicity = # of colors (size of equiv class)
 //    - gene multiplicity = # of distinct genes
 //    - add count, transcript multiplicity to tx_mappability
 //    - add count, gene multiplicity to gene_mappability
-// 3. Output results to tx_mappability.tsv and gene_mappability.tsc
+// 3. Output results to tx_mappability.tsv and gene_mappability.tsv
 //    - tx_mappability:
 //      tx_name gene_name length kmer_count fraction_unique_tx fraction_unique_gene
 // MappabilityRecord: tx_name, gene_name, tx_multiplicity: [usize], gene_multiplicity: [usize]

--- a/src/pseudoaligner.rs
+++ b/src/pseudoaligner.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::io::{self, Write};
 use std::path::Path;
 use std::sync::{mpsc, Arc, Mutex};
-use std::{self, cmp::Ordering, fs::File, str};
+use std::{self, fs::File, str};
 
 use bio::io::fastq;
 use boomphf::hashmap::NoKeyBoomHashMap;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -78,7 +78,7 @@ pub fn read_transcripts(
         let dna_string = DnaString::from_acgt_bytes_hashn(record.seq(), record.id().as_bytes());
         seqs.push(dna_string);
 
-        if let FastaFormat::Unknown = fasta_format{
+        if let FastaFormat::Unknown = fasta_format {
             fasta_format = detect_fasta_format(&record)?;
         }
 
@@ -113,20 +113,15 @@ pub fn detect_fasta_format(record: &fasta::Record) -> Result<FastaFormat, Error>
     if desc_tokens.len() >= 1 {
         let gene_tokens: Vec<&str> = desc_tokens[0].split('=').collect();
         if gene_tokens.len() == 2 && gene_tokens[0] == "gene" {
-            return Ok(FastaFormat::Gffread)
+            return Ok(FastaFormat::Gffread);
         }
     } else if desc_tokens.len() == 5 {
         return Ok(FastaFormat::Ensembl);
     }
-    Err(failure::err_msg(
-        "Failed to detect FASTA header format.",
-    ))
+    Err(failure::err_msg("Failed to detect FASTA header format."))
 }
 
-pub fn extract_tx_gene_id(
-    record: &fasta::Record,
-    fasta_format: &FastaFormat,
-) -> (String, String) {
+pub fn extract_tx_gene_id(record: &fasta::Record, fasta_format: &FastaFormat) -> (String, String) {
     match *fasta_format {
         FastaFormat::Gencode => {
             let id_tokens: Vec<&str> = record.id().split('|').collect();
@@ -141,7 +136,7 @@ pub fn extract_tx_gene_id(
             let gene_tmp: Vec<&str> = desc_tokens[2].split(':').collect();
             let gene_id = gene_tmp[1].to_string();
             (tx_id, gene_id)
-        },
+        }
         FastaFormat::Gffread => {
             let id_tokens: Vec<&str> = record.id().split(' ').collect();
             let tx_id = id_tokens[0].to_string();
@@ -149,7 +144,7 @@ pub fn extract_tx_gene_id(
             let gene_tokens: Vec<&str> = desc_tokens[0].split('=').collect();
             let gene_id = gene_tokens[1].to_string();
             (tx_id, gene_id)
-        },
+        }
         FastaFormat::Unknown => {
             panic!("fasta_format was uninitialized");
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,7 +21,7 @@ use crate::config;
 use crate::mappability::MappabilityRecord;
 
 const MAPPABILITY_HEADER_STRING: &'static str =
-    "tx_name\tgene_name\ttx_kmer_count\ttx_fraction_unique\tgene_fraction_unique\n";
+    "tx_name\tgene_id\tgene_name\ttx_kmer_count\ttx_fraction_unique\tgene_fraction_unique\n";
 
 pub fn write_obj<T: Serialize, P: AsRef<Path> + Debug>(
     g: &T,
@@ -182,6 +182,7 @@ pub fn write_mappability_tsv<P: AsRef<Path>>(
             outfile,
             "{}\t{}\t{}\t{}\t{}\n",
             record.tx_name,
+            record.gene_id,
             record.gene_name,
             record.total_kmer_count(),
             record.fraction_unique_tx(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,11 +17,11 @@ use bio::io::{fasta, fastq};
 use debruijn::dna_string::DnaString;
 use log::info;
 
-use crate::config;
+use crate::config::FastaFormat;
 use crate::mappability::MappabilityRecord;
 
 const MAPPABILITY_HEADER_STRING: &'static str =
-    "tx_name\tgene_id\tgene_name\ttx_kmer_count\ttx_fraction_unique\tgene_fraction_unique\n";
+    "tx_name\tgene_name\ttx_kmer_count\tfrac_kmer_unique_tx\tfrac_kmer_unique_gene\n";
 
 pub fn write_obj<T: Serialize, P: AsRef<Path> + Debug>(
     g: &T,
@@ -67,8 +67,7 @@ pub fn read_transcripts(
     let mut transcript_counter = 0;
     let mut tx_ids = Vec::new();
     let mut tx_to_gene_map = HashMap::new();
-
-    let mut fasta_format: Option<u8> = None;
+    let mut fasta_format = FastaFormat::Unknown;
 
     info!("Starting reading the Fasta file\n");
     for result in reader.records() {
@@ -79,11 +78,11 @@ pub fn read_transcripts(
         let dna_string = DnaString::from_acgt_bytes_hashn(record.seq(), record.id().as_bytes());
         seqs.push(dna_string);
 
-        if let None = fasta_format {
-            fasta_format = detect_fasta_format(&record);
+        if let FastaFormat::Unknown = fasta_format{
+            fasta_format = detect_fasta_format(&record)?;
         }
 
-        let (tx_id, gene_id, _) = extract_tx_gene_id(&record, fasta_format)?;
+        let (tx_id, gene_id) = extract_tx_gene_id(&record, &fasta_format);
 
         tx_ids.push(tx_id.clone());
         tx_to_gene_map.insert(tx_id, gene_id);
@@ -104,55 +103,56 @@ pub fn read_transcripts(
     Ok((seqs, tx_ids, tx_to_gene_map))
 }
 
-pub fn detect_fasta_format(record: &fasta::Record) -> Option<u8> {
+pub fn detect_fasta_format(record: &fasta::Record) -> Result<FastaFormat, Error> {
     let id_tokens: Vec<&str> = record.id().split('|').collect();
     if id_tokens.len() == 9 {
-        return Some(config::FASTA_FORMAT_GENCODE);
+        return Ok(FastaFormat::Gencode);
     }
 
     let desc_tokens: Vec<&str> = record.desc().unwrap().split(' ').collect();
     if desc_tokens.len() >= 1 {
         let gene_tokens: Vec<&str> = desc_tokens[0].split('=').collect();
         if gene_tokens.len() == 2 && gene_tokens[0] == "gene" {
-            return Some(config::FASTA_FORMAT_CUFFLINKS)
+            return Ok(FastaFormat::Gffread)
         }
     } else if desc_tokens.len() == 5 {
-        return Some(config::FASTA_FORMAT_ENSEMBL);
+        return Ok(FastaFormat::Ensembl);
     }
-
-    None
+    Err(failure::err_msg(
+        "Failed to detect FASTA header format.",
+    ))
 }
 
 pub fn extract_tx_gene_id(
     record: &fasta::Record,
-    fasta_format: Option<u8>,
-) -> Result<(String, String, String), Error> {
-    match fasta_format {
-        Some(config::FASTA_FORMAT_GENCODE) => {
+    fasta_format: &FastaFormat,
+) -> (String, String) {
+    match *fasta_format {
+        FastaFormat::Gencode => {
             let id_tokens: Vec<&str> = record.id().split('|').collect();
             let tx_id = id_tokens[0].to_string();
             let gene_id = id_tokens[1].to_string();
-            let gene_name = id_tokens[5].to_string();
-            Ok((tx_id, gene_id, gene_name))
+            // let gene_name = id_tokens[5].to_string();
+            (tx_id, gene_id)
         }
-        Some(config::FASTA_FORMAT_ENSEMBL) => {
+        FastaFormat::Ensembl => {
             let tx_id = record.id().to_string();
             let desc_tokens: Vec<&str> = record.desc().unwrap().split(' ').collect();
             let gene_tmp: Vec<&str> = desc_tokens[2].split(':').collect();
             let gene_id = gene_tmp[1].to_string();
-            Ok((tx_id, gene_id, "".to_string()))
+            (tx_id, gene_id)
         },
-        Some(config::FASTA_FORMAT_CUFFLINKS) => {
+        FastaFormat::Gffread => {
             let id_tokens: Vec<&str> = record.id().split(' ').collect();
             let tx_id = id_tokens[0].to_string();
             let desc_tokens: Vec<&str> = record.desc().unwrap().split(' ').collect();
             let gene_tokens: Vec<&str> = desc_tokens[0].split('=').collect();
             let gene_id = gene_tokens[1].to_string();
-            Ok((tx_id, gene_id, "".to_string()))
+            (tx_id, gene_id)
+        },
+        FastaFormat::Unknown => {
+            panic!("fasta_format was uninitialized");
         }
-        _ => Err(failure::err_msg(
-            "Unknown fasta format in extract_tx_gene_id.",
-        )),
     }
 }
 
@@ -182,7 +182,6 @@ pub fn write_mappability_tsv<P: AsRef<Path>>(
             outfile,
             "{}\t{}\t{}\t{}\t{}\n",
             record.tx_name,
-            record.gene_id,
             record.gene_name,
             record.total_kmer_count(),
             record.fraction_unique_tx(),


### PR DESCRIPTION
- Support the output of `gffread` (from Cufflinks), which can convert a standard genome fasta + annotation gtf/gff into the transcriptome fasta required for pseudoalignment:

```
gffread genes.gtf -g genome.fa -w transcriptome.fa
```

- cleaned up fasta_format checker
- comment out parsing of gene name (vs gene ID) because it's never used
- minor fixes: typo, unused import